### PR TITLE
Update markdown-pdf dependency to v9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'
+  - '10'

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 		"phantomjs"
 	],
 	"dependencies": {
-		"markdown-pdf": "^8.0.0",
+		"markdown-pdf": "^9.0.0",
 		"plugin-error": "^1.0.0",
 		"through2": "^2.0.0"
 	},


### PR DESCRIPTION
There's a [security vulnerability disclosed in markdown-pdf 8](https://nvd.nist.gov/vuln/detail/CVE-2018-3770). This just bumps the dependency to the newer markdown-pdf 9.x.y. 